### PR TITLE
[flash-calendar] add homepage to `package.json`

### DIFF
--- a/packages/flash-calendar/package.json
+++ b/packages/flash-calendar/package.json
@@ -8,6 +8,7 @@
     "url": "github.com/marceloprado/flash-calendar",
     "directory": "packages/flash-calendar"
   },
+  "homepage": "https://marceloprado.github.io/flash-calendar/",
   "license": "MIT",
   "author": "Marcelo Prado",
   "main": "./dist/index.js",


### PR DESCRIPTION
# Why & how

This PR adds the ["homepage" field](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#homepage) to the `package.json` file pointing out the the website. 

Thanks to that change the package website will be visible in the React Native Directory entry.