### PR TITLE
[doc] add border radius trick

### DIFF
--- a/apps/docs/docs/fundamentals/tips-and-tricks.mdx
+++ b/apps/docs/docs/fundamentals/tips-and-tricks.mdx
@@ -106,3 +106,20 @@ export function ImperativeScrolling() {
 </video>
 
 </HStack>
+
+## Setting Border Radius to `Calendar.Item.Day`
+
+To apply a border radius to the `Calendar.Item.Day` component, it's necessary to specify the radius for all four corners. Here's an example of how to achieve this:
+
+```tsx
+itemDay: {
+  base: () => ({
+    container: {
+      borderTopRightRadius: 10,
+      borderBottomRightRadius: 10,
+      borderTopLeftRadius: 10,
+      borderBottomLeftRadius: 10,
+    },
+  }),
+}
+```


### PR DESCRIPTION
## Changes: 

- Added a section to the `Tips and Tricks` screen called "Setting Border Radius to `Calendar.Item.Day`" to warn users how to apply `border-radius` properly. 

Here is the output:

![Screenshot 2024-03-01 at 7 35 13 PM](https://github.com/MarceloPrado/flash-calendar/assets/57192409/0172c060-9487-41d7-8393-651cb157818b)
