### PR TITLE
Improve borderRadius support

### DIFF
--- a/.changeset/spicy-starfishes-punch.md
+++ b/.changeset/spicy-starfishes-punch.md
@@ -1,0 +1,5 @@
+---
+"@marceloterreiro/flash-calendar": patch
+---
+
+Remove `borderRadius` type from `itemDay.container`, given it gets overwritten by the base component.

--- a/packages/flash-calendar/src/components/CalendarItemDay.tsx
+++ b/packages/flash-calendar/src/components/CalendarItemDay.tsx
@@ -24,7 +24,7 @@ const styles = StyleSheet.create({
 export type DayState = "idle" | "active" | "today" | "disabled";
 
 interface DayTheme {
-  container: ViewStyle;
+  container: Omit<ViewStyle, "borderRadius">;
   content: TextStyle;
 }
 type CalendarItemDayTheme = Record<
@@ -44,7 +44,7 @@ const buildBaseStyles = (theme: BaseTheme): CalendarItemDayTheme => {
 
   return {
     active: ({ isPressed, isStartOfRange, isEndOfRange }) => {
-      const baseStyles: DayTheme = isPressed
+      const baseStyles: DayTheme & { container: ViewStyle } = isPressed
         ? {
             container: {
               ...styles.baseContainer,


### PR DESCRIPTION
Addition to #21 to ensure compile-time check error when consumers try to set `borderRadius`.