### PR TITLE
[feat]: Add ability to scroll to a week row

### DIFF
--- a/.changeset/shiny-pigs-talk.md
+++ b/.changeset/shiny-pigs-talk.md
@@ -1,0 +1,24 @@
+---
+"@marceloterreiro/flash-calendar": major
+---
+
+# Flash Calendar 1.0.0 🚢 🎉
+
+This release officially marks the package as ready for production use (`1.0.0`).
+While it's been stable since the first release, bumping to `1.0.0` was something
+I had in mind for a while.
+
+- New: Add `.scrollToMonth` and `.scrollToDate`, increasing the options available for imperative scrolling.
+
+## Breaking changes
+
+This release introduces one slightly change in behavior if you're app uses
+imperative scrolling. Previously, `.scrollToDate` would scroll to the month
+containing the date instead of the exact date. Now, `.scrollToDate` will scroll
+to the exact date as the name suggests.
+
+If you intentionally want to scroll to the month instead, a new `.scrollToMonth`
+method was added (same signature).
+
+I don't expect this to cause any issues for existing apps, but worth mentioned
+nonetheless.

--- a/apps/docs/docs/fundamentals/tips-and-tricks.mdx
+++ b/apps/docs/docs/fundamentals/tips-and-tricks.mdx
@@ -112,6 +112,12 @@ export function ImperativeScrolling() {
 
 </HStack>
 
+You can also pass an `additionalOffset` to fine-tune the scroll position:
+
+```tsx
+.scrollToDate(fromDateId("2024-07-01"), true, { additionalOffset: 4 })
+```
+
 ## Setting Border Radius to `Calendar.Item.Day`
 
 To apply a border radius to the `Calendar.Item.Day` component, it's necessary to

--- a/apps/docs/docs/fundamentals/tips-and-tricks.mdx
+++ b/apps/docs/docs/fundamentals/tips-and-tricks.mdx
@@ -48,7 +48,9 @@ These two convertions functions were [battle-tested](https://github.com/MarceloP
 
 ## Programmatically scrolling to a date
 
-Flash Calendar exposes a `ref` that allows imperative scrolling to a desired date.
+Flash Calendar exposes a `ref` that allows imperative scrolling to a desired
+date (`.scrollToDate`), a month (`.scrollToMonth`), or an offset
+(`.scrollToOffset`).
 
 <HStack spacing={24} alignItems="flex-start">
 
@@ -63,8 +65,11 @@ import { Button, Text, View } from "react-native";
 
 export function ImperativeScrolling() {
   const [currentMonth, setCurrentMonth] = useState(startOfMonth(new Date()));
-
   const ref = useRef<CalendarListRef>(null);
+
+  const onCalendarDayPress = useCallback((dateId: string) => {
+    ref.current?.scrollToDate(fromDateId(dateId), true);
+  }, []);
 
   return (
     <View style={{ paddingTop: 20, flex: 1 }}>
@@ -73,7 +78,7 @@ export function ImperativeScrolling() {
           onPress={() => {
             const pastMonth = subMonths(currentMonth, 1);
             setCurrentMonth(pastMonth);
-            ref.current?.scrollToDate(pastMonth, true);
+            ref.current?.scrollToMonth(pastMonth, true);
           }}
           title="Past month"
         />
@@ -82,7 +87,7 @@ export function ImperativeScrolling() {
           onPress={() => {
             const nextMonth = addMonths(currentMonth, 1);
             setCurrentMonth(nextMonth);
-            ref.current?.scrollToDate(nextMonth, true);
+            ref.current?.scrollToMonth(nextMonth, true);
           }}
           title="Next month"
         />
@@ -90,7 +95,7 @@ export function ImperativeScrolling() {
       <View style={{ flex: 1, width: "100%" }}>
         <Calendar.List
           calendarInitialMonthId={toDateId(currentMonth)}
-          onCalendarDayPress={(dateId) => console.log(`Pressed ${dateId}`)}
+          onCalendarDayPress={onCalendarDayPress}
           ref={ref}
         />
       </View>

--- a/kitchen-sink/expo/src/App.tsx
+++ b/kitchen-sink/expo/src/App.tsx
@@ -9,7 +9,7 @@ import { CalendarListDemo } from "./CalendarList";
 import { BottomSheetCalendar } from "./BottomSheetCalendar";
 import { CalendarCustomFormatting } from "./CalendarCustomFormatting";
 import { ImperativeScrolling } from "./ImperativeScroll";
-import { SlowExampleAddressed } from "./SlowExampleAddressed";
+// import { SlowExampleAddressed } from "./SlowExampleAddressed";
 
 export default function App() {
   const [demo, setDemo] = useState<"calendar" | "calendarList">("calendar");
@@ -33,10 +33,9 @@ export default function App() {
 
           {demo === "calendar" ? <CalendarDemo /> : <CalendarListDemo />}
         </View> */}
-        {/* <ImperativeScrolling /> */}
-        {/* <ImperativeScrolling /> */}
+        <ImperativeScrolling />
         {/* <BottomSheetCalendar /> */}
-        <SlowExampleAddressed />
+        {/* <SlowExampleAddressed /> */}
       </SafeAreaView>
     </GestureHandlerRootView>
   );

--- a/kitchen-sink/expo/src/ImperativeScroll.tsx
+++ b/kitchen-sink/expo/src/ImperativeScroll.tsx
@@ -1,13 +1,20 @@
 import { addMonths, subMonths, startOfMonth } from "date-fns";
 import type { CalendarListRef } from "@marceloterreiro/flash-calendar";
-import { Calendar, toDateId } from "@marceloterreiro/flash-calendar";
-import { useRef, useState } from "react";
+import {
+  Calendar,
+  toDateId,
+  fromDateId,
+} from "@marceloterreiro/flash-calendar";
+import { useCallback, useRef, useState } from "react";
 import { Button, Text, View } from "react-native";
 
 export function ImperativeScrolling() {
   const [currentMonth, setCurrentMonth] = useState(startOfMonth(new Date()));
-
   const ref = useRef<CalendarListRef>(null);
+
+  const onCalendarDayPress = useCallback((dateId: string) => {
+    ref.current?.scrollToDate(fromDateId(dateId), true);
+  }, []);
 
   return (
     <View style={{ paddingTop: 20, flex: 1 }}>
@@ -16,7 +23,7 @@ export function ImperativeScrolling() {
           onPress={() => {
             const pastMonth = subMonths(currentMonth, 1);
             setCurrentMonth(pastMonth);
-            ref.current?.scrollToDate(pastMonth, true);
+            ref.current?.scrollToMonth(pastMonth, true);
           }}
           title="Past month"
         />
@@ -25,7 +32,7 @@ export function ImperativeScrolling() {
           onPress={() => {
             const nextMonth = addMonths(currentMonth, 1);
             setCurrentMonth(nextMonth);
-            ref.current?.scrollToDate(nextMonth, true);
+            ref.current?.scrollToMonth(nextMonth, true);
           }}
           title="Next month"
         />
@@ -33,7 +40,7 @@ export function ImperativeScrolling() {
       <View style={{ flex: 1, width: "100%" }}>
         <Calendar.List
           calendarInitialMonthId={toDateId(currentMonth)}
-          onCalendarDayPress={(dateId) => console.log(`Pressed ${dateId}`)}
+          onCalendarDayPress={onCalendarDayPress}
           ref={ref}
         />
       </View>

--- a/packages/flash-calendar/src/components/CalendarList.stories.tsx
+++ b/packages/flash-calendar/src/components/CalendarList.stories.tsx
@@ -110,14 +110,24 @@ export function SpacingSparse() {
 export function ImperativeScrolling() {
   const [currentMonth, setCurrentMonth] = useState(startOfMonth(new Date()));
 
+  const [activeDateId, setActiveDateId] = useState<string | undefined>(
+    toDateId(addDays(currentMonth, 3))
+  );
+
+  const calendarActiveDateRanges = useMemo<CalendarActiveDateRange[]>(() => {
+    if (!activeDateId) return [];
+
+    return [{ startId: activeDateId, endId: activeDateId }];
+  }, [activeDateId]);
+
   const ref = useRef<CalendarListRef>(null);
 
   const onCalendarDayPress = useCallback((dateId: string) => {
-    loggingHandler("onCalendarDayPress");
-
     const additionalOffset = -2; // Offset to account for selected day paddingTop
-
-    ref.current?.scrollToWeek(fromDateId(dateId), true, additionalOffset);
+    ref.current?.scrollToDate(fromDateId(dateId), true, {
+      additionalOffset,
+    });
+    setActiveDateId(dateId);
   }, []);
 
   return (
@@ -128,7 +138,7 @@ export function ImperativeScrolling() {
             onPress={() => {
               const pastMonth = subMonths(currentMonth, 1);
               setCurrentMonth(pastMonth);
-              ref.current?.scrollToDate(pastMonth, true);
+              ref.current?.scrollToMonth(pastMonth, true);
             }}
             title="Past month"
           />
@@ -137,7 +147,7 @@ export function ImperativeScrolling() {
             onPress={() => {
               const nextMonth = addMonths(currentMonth, 1);
               setCurrentMonth(nextMonth);
-              ref.current?.scrollToDate(nextMonth, true);
+              ref.current?.scrollToMonth(nextMonth, true);
             }}
             title="Next month"
           />
@@ -146,12 +156,13 @@ export function ImperativeScrolling() {
           onPress={() => {
             const thisMonth = startOfMonth(new Date());
             setCurrentMonth(thisMonth);
-            ref.current?.scrollToDate(thisMonth, true);
+            ref.current?.scrollToMonth(thisMonth, true);
           }}
           title="Today"
         />
         <View style={{ flex: 1, width: "100%" }}>
           <Calendar.List
+            calendarActiveDateRanges={calendarActiveDateRanges}
             calendarInitialMonthId={toDateId(currentMonth)}
             onCalendarDayPress={onCalendarDayPress}
             ref={ref}

--- a/packages/flash-calendar/src/components/CalendarList.stories.tsx
+++ b/packages/flash-calendar/src/components/CalendarList.stories.tsx
@@ -7,7 +7,7 @@ import {
   startOfYear,
   subMonths,
 } from "date-fns";
-import { useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { Button, Text, View } from "react-native";
 
 import type { CalendarListProps, CalendarListRef } from "@/components";
@@ -16,7 +16,7 @@ import { HStack } from "@/components/HStack";
 import { VStack } from "@/components/VStack";
 import { paddingDecorator } from "@/developer/decorators";
 import { loggingHandler } from "@/developer/loggginHandler";
-import { toDateId } from "@/helpers/dates";
+import { fromDateId, toDateId } from "@/helpers/dates";
 import type { CalendarActiveDateRange } from "@/hooks/useCalendar";
 import { useDateRange } from "@/hooks/useDateRange";
 import { useTheme } from "@/hooks/useTheme";
@@ -112,6 +112,14 @@ export function ImperativeScrolling() {
 
   const ref = useRef<CalendarListRef>(null);
 
+  const onCalendarDayPress = useCallback((dateId: string) => {
+    loggingHandler("onCalendarDayPress");
+
+    const additionalOffset = -2; // Offset to account for selected day paddingTop
+
+    ref.current?.scrollToWeek(fromDateId(dateId), true, additionalOffset);
+  }, []);
+
   return (
     <View style={{ paddingTop: 20, flex: 1 }}>
       <VStack alignItems="center" grow spacing={20}>
@@ -145,7 +153,7 @@ export function ImperativeScrolling() {
         <View style={{ flex: 1, width: "100%" }}>
           <Calendar.List
             calendarInitialMonthId={toDateId(currentMonth)}
-            onCalendarDayPress={loggingHandler("onCalendarDayPress")}
+            onCalendarDayPress={onCalendarDayPress}
             ref={ref}
           />
         </View>

--- a/packages/flash-calendar/src/components/CalendarList.stories.tsx
+++ b/packages/flash-calendar/src/components/CalendarList.stories.tsx
@@ -123,10 +123,7 @@ export function ImperativeScrolling() {
   const ref = useRef<CalendarListRef>(null);
 
   const onCalendarDayPress = useCallback((dateId: string) => {
-    const additionalOffset = -2; // Offset to account for selected day paddingTop
-    ref.current?.scrollToDate(fromDateId(dateId), true, {
-      additionalOffset,
-    });
+    ref.current?.scrollToDate(fromDateId(dateId), true);
     setActiveDateId(dateId);
   }, []);
 

--- a/packages/flash-calendar/src/components/CalendarList.tsx
+++ b/packages/flash-calendar/src/components/CalendarList.tsx
@@ -90,11 +90,11 @@ export interface CalendarListProps
 }
 
 export interface CalendarListRef {
-  scrollToDate: (date: Date, animated: boolean) => void;
-  scrollToWeek: (
+  scrollToMonth: (date: Date, animated: boolean) => void;
+  scrollToDate: (
     date: Date,
     animated: boolean,
-    additionalOffset?: number
+    params?: { additionalOffset?: number }
   ) => void;
   scrollToOffset: (offset: number, animated: boolean) => void;
 }
@@ -271,7 +271,7 @@ export const CalendarList = memo(
       const flashListRef = useRef<FlashList<CalendarMonthEnhanced>>(null);
 
       useImperativeHandle(ref, () => ({
-        scrollToDate(date, animated) {
+        scrollToMonth(date, animated) {
           // Wait for the next render cycle to ensure the list has been
           // updated with the new months.
           setTimeout(() => {
@@ -281,19 +281,22 @@ export const CalendarList = memo(
             });
           }, 0);
         },
-        scrollToWeek(date, animated, additionalOffset = 0) {
+        scrollToDate(
+          date,
+          animated,
+          { additionalOffset = 0 } = {
+            additionalOffset: 0,
+          }
+        ) {
           const currentMonthOffset = getScrollOffsetForMonth(date);
 
-          const weekRowIndex = getWeekOfMonth(date, calendarFirstDayOfWeek);
-
-          const weekRowHeight =
+          const weekOfMonthIndex = getWeekOfMonth(date, calendarFirstDayOfWeek);
+          const rowHeight =
             calendarDayHeight + calendarRowVerticalSpacing + additionalOffset;
-
-          const weekPosition =
-            weekRowHeight * weekRowIndex + calendarWeekHeaderHeight;
-
+          const weekOffset =
+            calendarWeekHeaderHeight + rowHeight * weekOfMonthIndex;
           flashListRef.current?.scrollToOffset({
-            offset: currentMonthOffset + weekPosition,
+            offset: currentMonthOffset + weekOffset,
             animated,
           });
         },

--- a/packages/flash-calendar/src/components/CalendarList.tsx
+++ b/packages/flash-calendar/src/components/CalendarList.tsx
@@ -89,12 +89,23 @@ export interface CalendarListProps
   renderItem?: FlashListProps<CalendarMonthEnhanced>["renderItem"];
 }
 
+interface ImperativeScrollParams {
+  /**
+   * An additional offset to add to the final scroll position. Useful when
+   * you need to slightly change the final scroll position.
+   */
+  additionalOffset?: number;
+}
 export interface CalendarListRef {
-  scrollToMonth: (date: Date, animated: boolean) => void;
+  scrollToMonth: (
+    date: Date,
+    animated: boolean,
+    params?: ImperativeScrollParams
+  ) => void;
   scrollToDate: (
     date: Date,
     animated: boolean,
-    params?: { additionalOffset?: number }
+    params?: ImperativeScrollParams
   ) => void;
   scrollToOffset: (offset: number, animated: boolean) => void;
 }
@@ -230,6 +241,10 @@ export const CalendarList = memo(
         ]
       );
 
+      /**
+       * Returns the offset for the given month (how much the user needs to
+       * scroll to reach the month).
+       */
       const getScrollOffsetForMonth = useCallback(
         (date: Date) => {
           const monthId = toDateId(startOfMonth(date));
@@ -271,12 +286,16 @@ export const CalendarList = memo(
       const flashListRef = useRef<FlashList<CalendarMonthEnhanced>>(null);
 
       useImperativeHandle(ref, () => ({
-        scrollToMonth(date, animated) {
+        scrollToMonth(
+          date,
+          animated,
+          { additionalOffset = 0 } = { additionalOffset: 0 }
+        ) {
           // Wait for the next render cycle to ensure the list has been
           // updated with the new months.
           setTimeout(() => {
             flashListRef.current?.scrollToOffset({
-              offset: getScrollOffsetForMonth(date),
+              offset: getScrollOffsetForMonth(date) + additionalOffset,
               animated,
             });
           }, 0);
@@ -289,14 +308,22 @@ export const CalendarList = memo(
           }
         ) {
           const currentMonthOffset = getScrollOffsetForMonth(date);
-
           const weekOfMonthIndex = getWeekOfMonth(date, calendarFirstDayOfWeek);
-          const rowHeight =
-            calendarDayHeight + calendarRowVerticalSpacing + additionalOffset;
-          const weekOffset =
+          const rowHeight = calendarDayHeight + calendarRowVerticalSpacing;
+
+          let weekOffset =
             calendarWeekHeaderHeight + rowHeight * weekOfMonthIndex;
+
+          /**
+           * We need to subtract one vertical spacing to avoid cutting off the
+           * desired date. A simple way of understanding why is imagining we
+           * want to scroll exactly to the given date, but leave a little bit of
+           * breathing room (`calendarRowVerticalSpacing`) above it.
+           */
+          weekOffset = weekOffset - calendarRowVerticalSpacing;
+
           flashListRef.current?.scrollToOffset({
-            offset: currentMonthOffset + weekOffset,
+            offset: currentMonthOffset + weekOffset + additionalOffset,
             animated,
           });
         },

--- a/packages/flash-calendar/src/components/CalendarList.tsx
+++ b/packages/flash-calendar/src/components/CalendarList.tsx
@@ -13,11 +13,7 @@ import { View } from "react-native";
 
 import type { CalendarProps } from "@/components/Calendar";
 import { Calendar } from "@/components/Calendar";
-import {
-  getWeekRowIndexInMonth,
-  startOfMonth,
-  toDateId,
-} from "@/helpers/dates";
+import { getWeekOfMonth, startOfMonth, toDateId } from "@/helpers/dates";
 import type { CalendarMonth } from "@/hooks/useCalendarList";
 import { getHeightForMonth, useCalendarList } from "@/hooks/useCalendarList";
 
@@ -288,10 +284,7 @@ export const CalendarList = memo(
         scrollToWeek(date, animated, additionalOffset = 0) {
           const currentMonthOffset = getScrollOffsetForMonth(date);
 
-          const weekRowIndex = getWeekRowIndexInMonth(
-            date,
-            calendarFirstDayOfWeek
-          );
+          const weekRowIndex = getWeekOfMonth(date, calendarFirstDayOfWeek);
 
           const weekRowHeight =
             calendarDayHeight + calendarRowVerticalSpacing + additionalOffset;

--- a/packages/flash-calendar/src/helpers/dates.test.ts
+++ b/packages/flash-calendar/src/helpers/dates.test.ts
@@ -23,6 +23,7 @@ import {
   isWeekend,
   differenceInMonths,
   getWeeksInMonth,
+  getWeekRowIndexInMonth,
 } from "@/helpers/dates";
 import { range } from "@/helpers/numbers";
 import { pipe } from "@/helpers/functions";
@@ -526,5 +527,60 @@ describe("getWeeksInMonth", () => {
       expect(getWeeksInMonth(date, "monday")).toBe(countMonday);
       expect(getWeeksInMonth(date, "sunday")).toBe(countSunday);
     });
+  });
+});
+
+describe("getWeekRowIndexInMonth", () => {
+  const getWeekRowIndexInMonth_sunday = (date: Date) =>
+    getWeekRowIndexInMonth(date, "sunday");
+
+  const getWeekRowIndexInMonth_monday = (date: Date) =>
+    getWeekRowIndexInMonth(date, "monday");
+
+  it("sunday: June", () => {
+    expect(pipe(fromDateId("2024-06-01"), getWeekRowIndexInMonth_sunday)).toBe(
+      1
+    );
+    expect(pipe(fromDateId("2024-06-02"), getWeekRowIndexInMonth_sunday)).toBe(
+      2
+    );
+    expect(pipe(fromDateId("2024-06-03"), getWeekRowIndexInMonth_monday)).toBe(
+      2
+    );
+    expect(pipe(fromDateId("2024-06-12"), getWeekRowIndexInMonth_sunday)).toBe(
+      3
+    );
+    expect(pipe(fromDateId("2024-06-22"), getWeekRowIndexInMonth_sunday)).toBe(
+      4
+    );
+    expect(pipe(fromDateId("2024-06-28"), getWeekRowIndexInMonth_sunday)).toBe(
+      5
+    );
+    expect(pipe(fromDateId("2024-06-30"), getWeekRowIndexInMonth_sunday)).toBe(
+      6
+    );
+  });
+  it("monday: June", () => {
+    expect(pipe(fromDateId("2024-06-01"), getWeekRowIndexInMonth_monday)).toBe(
+      1
+    );
+    expect(pipe(fromDateId("2024-06-02"), getWeekRowIndexInMonth_monday)).toBe(
+      1
+    );
+    expect(pipe(fromDateId("2024-06-03"), getWeekRowIndexInMonth_monday)).toBe(
+      2
+    );
+    expect(pipe(fromDateId("2024-06-12"), getWeekRowIndexInMonth_monday)).toBe(
+      3
+    );
+    expect(pipe(fromDateId("2024-06-22"), getWeekRowIndexInMonth_monday)).toBe(
+      4
+    );
+    expect(pipe(fromDateId("2024-06-28"), getWeekRowIndexInMonth_monday)).toBe(
+      5
+    );
+    expect(pipe(fromDateId("2024-06-30"), getWeekRowIndexInMonth_monday)).toBe(
+      5
+    );
   });
 });

--- a/packages/flash-calendar/src/helpers/dates.test.ts
+++ b/packages/flash-calendar/src/helpers/dates.test.ts
@@ -8,6 +8,7 @@ import {
   addMonths as addMonthsDateFns,
   subMonths as subMonthsDateFns,
   getWeeksInMonth as getWeeksInMonthDateFns,
+  getWeekOfMonth as getWeekOfMonthDateFns,
 } from "date-fns";
 
 import {
@@ -23,7 +24,7 @@ import {
   isWeekend,
   differenceInMonths,
   getWeeksInMonth,
-  getWeekRowIndexInMonth,
+  getWeekOfMonth,
 } from "@/helpers/dates";
 import { range } from "@/helpers/numbers";
 import { pipe } from "@/helpers/functions";
@@ -530,57 +531,37 @@ describe("getWeeksInMonth", () => {
   });
 });
 
-describe("getWeekRowIndexInMonth", () => {
-  const getWeekRowIndexInMonth_sunday = (date: Date) =>
-    getWeekRowIndexInMonth(date, "sunday");
-
-  const getWeekRowIndexInMonth_monday = (date: Date) =>
-    getWeekRowIndexInMonth(date, "monday");
+describe("getWeekOfMonth", () => {
+  const getWeekOfMonth_sunday = (date: Date) => getWeekOfMonth(date, "sunday");
+  const getWeekOfMonth_monday = (date: Date) => getWeekOfMonth(date, "monday");
 
   it("sunday: June", () => {
-    expect(pipe(fromDateId("2024-06-01"), getWeekRowIndexInMonth_sunday)).toBe(
-      1
-    );
-    expect(pipe(fromDateId("2024-06-02"), getWeekRowIndexInMonth_sunday)).toBe(
-      2
-    );
-    expect(pipe(fromDateId("2024-06-03"), getWeekRowIndexInMonth_monday)).toBe(
-      2
-    );
-    expect(pipe(fromDateId("2024-06-12"), getWeekRowIndexInMonth_sunday)).toBe(
-      3
-    );
-    expect(pipe(fromDateId("2024-06-22"), getWeekRowIndexInMonth_sunday)).toBe(
-      4
-    );
-    expect(pipe(fromDateId("2024-06-28"), getWeekRowIndexInMonth_sunday)).toBe(
-      5
-    );
-    expect(pipe(fromDateId("2024-06-30"), getWeekRowIndexInMonth_sunday)).toBe(
-      6
-    );
+    expect(pipe(fromDateId("2024-06-01"), getWeekOfMonth_sunday)).toBe(1);
+    expect(pipe(fromDateId("2024-06-02"), getWeekOfMonth_sunday)).toBe(2);
+    expect(pipe(fromDateId("2024-06-03"), getWeekOfMonth_monday)).toBe(2);
+    expect(pipe(fromDateId("2024-06-12"), getWeekOfMonth_sunday)).toBe(3);
+    expect(pipe(fromDateId("2024-06-22"), getWeekOfMonth_sunday)).toBe(4);
+    expect(pipe(fromDateId("2024-06-28"), getWeekOfMonth_sunday)).toBe(5);
+    expect(pipe(fromDateId("2024-06-30"), getWeekOfMonth_sunday)).toBe(6);
   });
   it("monday: June", () => {
-    expect(pipe(fromDateId("2024-06-01"), getWeekRowIndexInMonth_monday)).toBe(
-      1
-    );
-    expect(pipe(fromDateId("2024-06-02"), getWeekRowIndexInMonth_monday)).toBe(
-      1
-    );
-    expect(pipe(fromDateId("2024-06-03"), getWeekRowIndexInMonth_monday)).toBe(
-      2
-    );
-    expect(pipe(fromDateId("2024-06-12"), getWeekRowIndexInMonth_monday)).toBe(
-      3
-    );
-    expect(pipe(fromDateId("2024-06-22"), getWeekRowIndexInMonth_monday)).toBe(
-      4
-    );
-    expect(pipe(fromDateId("2024-06-28"), getWeekRowIndexInMonth_monday)).toBe(
-      5
-    );
-    expect(pipe(fromDateId("2024-06-30"), getWeekRowIndexInMonth_monday)).toBe(
-      5
-    );
+    expect(pipe(fromDateId("2024-06-01"), getWeekOfMonth_monday)).toBe(1);
+    expect(pipe(fromDateId("2024-06-02"), getWeekOfMonth_monday)).toBe(1);
+    expect(pipe(fromDateId("2024-06-03"), getWeekOfMonth_monday)).toBe(2);
+    expect(pipe(fromDateId("2024-06-12"), getWeekOfMonth_monday)).toBe(3);
+    expect(pipe(fromDateId("2024-06-22"), getWeekOfMonth_monday)).toBe(4);
+    expect(pipe(fromDateId("2024-06-28"), getWeekOfMonth_monday)).toBe(5);
+    expect(pipe(fromDateId("2024-06-30"), getWeekOfMonth_monday)).toBe(5);
+  });
+  it("matches date-fns", () => {
+    const baseDate = fromDateId("2024-06-01");
+    range(1, 500).forEach((i) => {
+      const date = addDays(baseDate, i);
+      const countMonday = getWeekOfMonthDateFns(date, { weekStartsOn: 1 });
+      const countSunday = getWeekOfMonthDateFns(date, { weekStartsOn: 0 });
+
+      expect(getWeekOfMonth(date, "monday")).toBe(countMonday);
+      expect(getWeekOfMonth(date, "sunday")).toBe(countSunday);
+    });
   });
 });

--- a/packages/flash-calendar/src/helpers/dates.ts
+++ b/packages/flash-calendar/src/helpers/dates.ts
@@ -143,11 +143,9 @@ export function getWeeksInMonth(
 }
 
 /**
- * Get the week row index of the given date in the month.
- * The week index is 1-based.
+ * Get the week of the month of the given date. The week index is 1-based.
  */
-
-export function getWeekRowIndexInMonth(
+export function getWeekOfMonth(
   date: Date,
   firstDayOfWeek: "monday" | "sunday"
 ) {

--- a/packages/flash-calendar/src/helpers/dates.ts
+++ b/packages/flash-calendar/src/helpers/dates.ts
@@ -141,3 +141,25 @@ export function getWeeksInMonth(
 
   return Math.ceil((dayOfWeek + totalDays) / 7);
 }
+
+/**
+ * Get the week row index of the given date in the month.
+ * The week index is 1-based.
+ */
+
+export function getWeekRowIndexInMonth(
+  date: Date,
+  firstDayOfWeek: "monday" | "sunday"
+) {
+  const firstDay = new Date(date.getFullYear(), date.getMonth(), 1);
+  let dayOfWeek = firstDay.getDay();
+
+  // Adjust the first day of the week
+  if (firstDayOfWeek === "monday") {
+    dayOfWeek = dayOfWeek === 0 ? 6 : dayOfWeek - 1;
+  }
+
+  const dayOfMonth = date.getDate();
+
+  return Math.floor((dayOfWeek + dayOfMonth - 1) / 7) + 1;
+}


### PR DESCRIPTION
First of all, thanks @MarceloPrado for this library it is so much better than any other available library for react native.

This PR aims to give more flexibility to users by exposing `scrollToOffset` method to calendarRef and also adds a new ref method to scroll to a week row, `scrollToWeek`. 
The motivation for this new method comes from my project's design with a fixed `weekHeader` but I figured it could be useful for other people.

My project example:

https://github.com/MarceloPrado/flash-calendar/assets/20520102/0a40554c-f517-44e5-8797-611f7eeee50e 

Flash calendar storybook:

https://github.com/MarceloPrado/flash-calendar/assets/20520102/20d7f056-d1f7-4633-8d0e-e701e837b6c4

I'd also suggest to change the name of `scrollToDate` to `scrollToMonth`, because at first I thought the behavior was to scroll to the date/row itself rather than to MonthHeader, but that would have an impact on the API so I understand it might not be a priority since the docs explain the behavior.