### PR TITLE
feat(textProps): adding ability to spread TextProps to help with accessibility

### DIFF
--- a/.changeset/curvy-files-teach.md
+++ b/.changeset/curvy-files-teach.md
@@ -1,0 +1,5 @@
+---
+"@marceloterreiro/flash-calendar": minor
+---
+
+Add the ability to pass TextProps to the <Text> fields especially when supporting accessibility

--- a/apps/docs/docs/fundamentals/customization.mdx
+++ b/apps/docs/docs/fundamentals/customization.mdx
@@ -128,6 +128,66 @@ Check out the full source code [here](https://github.com/MarceloPrado/flash-cale
 
 Sometimes, you need more than just changing styles. You might want to change the layout, add new components, or even remove some of them. In this case, you can easily build your own calendar using the base Calendar components from [above](#anatomy).
 
+You can override the `textProps` to control the nested [Text components](https://reactnative.dev/docs/text). For example [disabling font scaling](https://reactnative.dev/docs/text#allowfontscaling) for accessibility on the Calendar's Day:
+
+```tsx
+import {
+  Calendar,
+  useOptimizedDayMetadata,
+} from "@marceloterreiro/flash-calendar";
+import { Text } from "react-native";
+import type { CalendarItemDayWithContainerProps } from "@/components/CalendarItemDay";
+
+import { useRenderCount } from "./useRenderCount";
+
+export const PerfTestCalendarItemDayWithContainer = ({
+  children,
+  metadata: baseMetadata,
+  onPress,
+  theme,
+  dayHeight,
+  daySpacing,
+  containerTheme,
+}: CalendarItemDayWithContainerProps) => {
+  const metadata = useOptimizedDayMetadata(baseMetadata);
+  const renderCounter = useRenderCount();
+
+  return (
+    <Calendar.Item.Day.Container
+      dayHeight={dayHeight}
+      daySpacing={daySpacing}
+      isStartOfWeek={metadata.isStartOfWeek}
+      shouldShowActiveDayFiller={
+        metadata.isRangeValid && !metadata.isEndOfWeek
+          ? !metadata.isEndOfRange
+          : false
+      }
+      theme={containerTheme}
+    >
+      <Calendar.Item.Day
+        textProps={{ allowFontScaling: false }}
+        height={dayHeight}
+        metadata={metadata}
+        onPress={onPress}
+        theme={theme}
+      >
+        {children}
+        <Text
+          style={{
+            fontSize: 8,
+            fontStyle: "italic",
+            textAlign: "center",
+            color: metadata.state === "active" ? "white" : "black",
+          }}
+        >
+          {"\n"}render: {renderCounter}x
+        </Text>
+      </Calendar.Item.Day>
+    </Calendar.Item.Day.Container>
+  );
+};
+```
+
 The sky is the limit here. Here are two demos from the example app:
 
 <HStack spacing={24} alignItems="flex-start">

--- a/apps/docs/docs/fundamentals/customization.mdx
+++ b/apps/docs/docs/fundamentals/customization.mdx
@@ -128,6 +128,38 @@ Check out the full source code [here](https://github.com/MarceloPrado/flash-cale
 
 Sometimes, you need more than just changing styles. You might want to change the layout, add new components, or even remove some of them. In this case, you can easily build your own calendar using the base Calendar components from [above](#anatomy).
 
+The sky is the limit here. Here are two demos from the example app:
+
+<HStack spacing={24} alignItems="flex-start">
+
+<VStack spacing={12} alignItems="center">
+  <VStack spacing={4} alignItems="center">
+
+    <span style={{ fontWeight: "bold" }}>Windows XP calendar • [source code](https://github.com/MarceloPrado/flash-calendar/blob/468c7153257489a3a527bd400d532223bf35dd0c/apps/example/src/components/ThemeableCalendar/Calendar.stories.tsx#L41-L106)</span>
+    <span style={{ opacity: 0.8 }}>A nostalgic rebuild to showcase what's possible with Flash Calendar.</span>
+
+  </VStack>
+  <video controls width={300}>
+    <source src={windowsXpCalendarVideo} type="video/mp4" />
+  </video>
+</VStack>
+
+<VStack spacing={12} alignItems="center">
+  <VStack spacing={4} alignItems="center">
+
+    <span style={{ fontWeight: "bold", margin: 0 }}>Perf calendar • [source code](https://github.com/MarceloPrado/flash-calendar/blob/468c7153257489a3a527bd400d532223bf35dd0c/apps/example/src/components/PerfTestCalendar/PerfTestCalendarList.stories.tsx#L47-L67)</span>
+    <span style={{ opacity: 0.8, margin: 0 }}>A calendar built to measure re-renders.</span>
+
+  </VStack>
+  <video controls width={300}>
+    <source src={perfCalendarVideo} type="video/mp4" />
+  </video>
+</VStack>
+
+</HStack>
+
+### Changing the text props
+
 You can override the `textProps` to control the nested [Text components](https://reactnative.dev/docs/text). For example [disabling font scaling](https://reactnative.dev/docs/text#allowfontscaling) for accessibility on the Calendar's Day:
 
 ```tsx
@@ -187,33 +219,3 @@ export const PerfTestCalendarItemDayWithContainer = ({
   );
 };
 ```
-
-The sky is the limit here. Here are two demos from the example app:
-
-<HStack spacing={24} alignItems="flex-start">
-
-<VStack spacing={12} alignItems="center">
-  <VStack spacing={4} alignItems="center">
-
-    <span style={{ fontWeight: "bold" }}>Windows XP calendar • [source code](https://github.com/MarceloPrado/flash-calendar/blob/468c7153257489a3a527bd400d532223bf35dd0c/apps/example/src/components/ThemeableCalendar/Calendar.stories.tsx#L41-L106)</span>
-    <span style={{ opacity: 0.8 }}>A nostalgic rebuild to showcase what's possible with Flash Calendar.</span>
-
-  </VStack>
-  <video controls width={300}>
-    <source src={windowsXpCalendarVideo} type="video/mp4" />
-  </video>
-</VStack>
-
-<VStack spacing={12} alignItems="center">
-  <VStack spacing={4} alignItems="center">
-
-    <span style={{ fontWeight: "bold", margin: 0 }}>Perf calendar • [source code](https://github.com/MarceloPrado/flash-calendar/blob/468c7153257489a3a527bd400d532223bf35dd0c/apps/example/src/components/PerfTestCalendar/PerfTestCalendarList.stories.tsx#L47-L67)</span>
-    <span style={{ opacity: 0.8, margin: 0 }}>A calendar built to measure re-renders.</span>
-
-  </VStack>
-  <video controls width={300}>
-    <source src={perfCalendarVideo} type="video/mp4" />
-  </video>
-</VStack>
-
-</HStack>

--- a/packages/flash-calendar/src/components/CalendarItemDay.tsx
+++ b/packages/flash-calendar/src/components/CalendarItemDay.tsx
@@ -1,13 +1,7 @@
 import type { ReactNode } from "react";
 import { useCallback, useMemo } from "react";
-import type { TextStyle, ViewStyle } from "react-native";
-import {
-  Pressable,
-  StyleSheet,
-  Text,
-  type TextProps,
-  View,
-} from "react-native";
+import type { TextProps, TextStyle, ViewStyle } from "react-native";
+import { Pressable, StyleSheet, Text, View } from "react-native";
 
 import type { BaseTheme } from "@/helpers/tokens";
 import type { CalendarDayMetadata } from "@/hooks/useCalendar";

--- a/packages/flash-calendar/src/components/CalendarItemDay.tsx
+++ b/packages/flash-calendar/src/components/CalendarItemDay.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import { useCallback, useMemo } from "react";
 import type { TextStyle, ViewStyle } from "react-native";
-import { Pressable, StyleSheet, Text, View } from "react-native";
+import { Pressable, StyleSheet, Text, type TextProps, View } from "react-native";
 
 import type { BaseTheme } from "@/helpers/tokens";
 import type { CalendarDayMetadata } from "@/hooks/useCalendar";
@@ -126,7 +126,7 @@ const buildBaseStyles = (theme: BaseTheme): CalendarItemDayTheme => {
   };
 };
 
-export interface CalendarItemDayProps {
+export interface CalendarItemDayProps extends Omit<TextProps, 'onPress'> {
   children: ReactNode;
   onPress: (id: string) => void;
   metadata: CalendarDayMetadata;
@@ -158,6 +158,7 @@ export const CalendarItemDay = ({
   theme,
   height,
   metadata,
+  ...rest
 }: CalendarItemDayProps) => {
   const baseTheme = useTheme();
   const baseStyles = useMemo(() => {
@@ -196,6 +197,7 @@ export const CalendarItemDay = ({
         const { content } = baseStyles[metadata.state](params);
         return (
           <Text
+            {...rest}
             style={{
               ...content,
               ...theme?.base?.({ ...metadata, isPressed }).content,

--- a/packages/flash-calendar/src/components/CalendarItemDay.tsx
+++ b/packages/flash-calendar/src/components/CalendarItemDay.tsx
@@ -143,7 +143,7 @@ export interface CalendarItemDayProps {
   /** The cell's height */
   height: number;
   /** Optional TextProps to spread to the <Text> component. */
-  textProps: Omit<TextProps, "children" | "onPress">;
+  textProps?: Omit<TextProps, "children" | "onPress">;
 }
 
 /**

--- a/packages/flash-calendar/src/components/CalendarItemDay.tsx
+++ b/packages/flash-calendar/src/components/CalendarItemDay.tsx
@@ -1,7 +1,13 @@
 import type { ReactNode } from "react";
 import { useCallback, useMemo } from "react";
 import type { TextStyle, ViewStyle } from "react-native";
-import { Pressable, StyleSheet, Text, type TextProps, View } from "react-native";
+import {
+  Pressable,
+  StyleSheet,
+  Text,
+  type TextProps,
+  View,
+} from "react-native";
 
 import type { BaseTheme } from "@/helpers/tokens";
 import type { CalendarDayMetadata } from "@/hooks/useCalendar";
@@ -126,7 +132,8 @@ const buildBaseStyles = (theme: BaseTheme): CalendarItemDayTheme => {
   };
 };
 
-export interface CalendarItemDayProps extends Omit<TextProps, 'onPress'> {
+export interface CalendarItemDayProps
+  extends Omit<TextProps, "children" | "onPress"> {
   children: ReactNode;
   onPress: (id: string) => void;
   metadata: CalendarDayMetadata;

--- a/packages/flash-calendar/src/components/CalendarItemDay.tsx
+++ b/packages/flash-calendar/src/components/CalendarItemDay.tsx
@@ -126,8 +126,7 @@ const buildBaseStyles = (theme: BaseTheme): CalendarItemDayTheme => {
   };
 };
 
-export interface CalendarItemDayProps
-  extends Omit<TextProps, "children" | "onPress"> {
+export interface CalendarItemDayProps {
   children: ReactNode;
   onPress: (id: string) => void;
   metadata: CalendarDayMetadata;
@@ -143,6 +142,8 @@ export interface CalendarItemDayProps
   >;
   /** The cell's height */
   height: number;
+  /** Optional TextProps to spread to the <Text> component. */
+  textProps: Omit<TextProps, "children" | "onPress">;
 }
 
 /**
@@ -159,7 +160,7 @@ export const CalendarItemDay = ({
   theme,
   height,
   metadata,
-  ...rest
+  textProps,
 }: CalendarItemDayProps) => {
   const baseTheme = useTheme();
   const baseStyles = useMemo(() => {
@@ -198,7 +199,7 @@ export const CalendarItemDay = ({
         const { content } = baseStyles[metadata.state](params);
         return (
           <Text
-            {...rest}
+            {...textProps}
             style={{
               ...content,
               ...theme?.base?.({ ...metadata, isPressed }).content,

--- a/packages/flash-calendar/src/components/CalendarItemDay.tsx
+++ b/packages/flash-calendar/src/components/CalendarItemDay.tsx
@@ -202,6 +202,7 @@ export const CalendarItemDay = ({
             {...textProps}
             style={{
               ...content,
+              ...(textProps?.style ?? ({} as object)),
               ...theme?.base?.({ ...metadata, isPressed }).content,
               ...theme?.[metadata.state]?.({ ...metadata, isPressed }).content,
             }}

--- a/packages/flash-calendar/src/components/CalendarItemWeekName.tsx
+++ b/packages/flash-calendar/src/components/CalendarItemWeekName.tsx
@@ -21,7 +21,7 @@ interface CalendarItemWeekNameTheme {
   content?: TextStyle;
 }
 
-export interface CalendarItemWeekNameProps extends TextProps {
+export interface CalendarItemWeekNameProps extends Omit<TextProps, "children"> {
   children: ReactNode;
   /**
    * The height of the week name, needed to correctly measure the calendar's
@@ -50,7 +50,9 @@ export const CalendarItemWeekName = ({
 
   return (
     <View style={containerStyles}>
-      <Text {...rest} style={contentStyles}>{children}</Text>
+      <Text {...rest} style={contentStyles}>
+        {children}
+      </Text>
     </View>
   );
 };

--- a/packages/flash-calendar/src/components/CalendarItemWeekName.tsx
+++ b/packages/flash-calendar/src/components/CalendarItemWeekName.tsx
@@ -21,7 +21,7 @@ interface CalendarItemWeekNameTheme {
   content?: TextStyle;
 }
 
-export interface CalendarItemWeekNameProps extends Omit<TextProps, "children"> {
+export interface CalendarItemWeekNameProps {
   children: ReactNode;
   /**
    * The height of the week name, needed to correctly measure the calendar's
@@ -29,13 +29,15 @@ export interface CalendarItemWeekNameProps extends Omit<TextProps, "children"> {
   height: number;
   /** The theme of the week name, useful for customizing the component. */
   theme?: CalendarItemWeekNameTheme;
+  /** Optional TextProps to spread to the <Text> component. */
+  textProps?: Omit<TextProps, "children">;
 }
 
 export const CalendarItemWeekName = ({
   children,
   height,
   theme,
-  ...rest
+  textProps,
 }: CalendarItemWeekNameProps) => {
   const { colors } = useTheme();
   const { containerStyles, contentStyles } = useMemo(() => {
@@ -50,7 +52,7 @@ export const CalendarItemWeekName = ({
 
   return (
     <View style={containerStyles}>
-      <Text {...rest} style={contentStyles}>
+      <Text {...textProps} style={contentStyles}>
         {children}
       </Text>
     </View>

--- a/packages/flash-calendar/src/components/CalendarItemWeekName.tsx
+++ b/packages/flash-calendar/src/components/CalendarItemWeekName.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { useMemo } from "react";
-import type { TextStyle, ViewStyle } from "react-native";
+import type { TextProps, TextStyle, ViewStyle } from "react-native";
 import { StyleSheet, Text, View } from "react-native";
 
 import { lightTheme } from "@/helpers/tokens";
@@ -21,7 +21,7 @@ interface CalendarItemWeekNameTheme {
   content?: TextStyle;
 }
 
-export interface CalendarItemWeekNameProps {
+export interface CalendarItemWeekNameProps extends TextProps {
   children: ReactNode;
   /**
    * The height of the week name, needed to correctly measure the calendar's
@@ -35,6 +35,7 @@ export const CalendarItemWeekName = ({
   children,
   height,
   theme,
+  ...rest
 }: CalendarItemWeekNameProps) => {
   const { colors } = useTheme();
   const { containerStyles, contentStyles } = useMemo(() => {
@@ -49,7 +50,7 @@ export const CalendarItemWeekName = ({
 
   return (
     <View style={containerStyles}>
-      <Text style={contentStyles}>{children}</Text>
+      <Text {...rest} style={contentStyles}>{children}</Text>
     </View>
   );
 };

--- a/packages/flash-calendar/src/components/CalendarItemWeekName.tsx
+++ b/packages/flash-calendar/src/components/CalendarItemWeekName.tsx
@@ -45,10 +45,17 @@ export const CalendarItemWeekName = ({
     const contentStyles = [
       styles.content,
       { color: colors.content.primary },
+      textProps?.style,
       theme?.content,
     ];
     return { containerStyles, contentStyles };
-  }, [colors.content.primary, height, theme?.container, theme?.content]);
+  }, [
+    colors.content.primary,
+    height,
+    theme?.container,
+    theme?.content,
+    textProps?.style,
+  ]);
 
   return (
     <View style={containerStyles}>


### PR DESCRIPTION
Adding ability to override TextProps when customizing the calendar especially for accessibility.

Resolves https://github.com/MarceloPrado/flash-calendar/issues/61 and https://github.com/MarceloPrado/flash-calendar/issues/36