### PR TITLE
feat(web): Support InteractionStates like hovered and focused for web

### DIFF
--- a/.changeset/rich-cars-taste.md
+++ b/.changeset/rich-cars-taste.md
@@ -1,0 +1,5 @@
+---
+"@marceloterreiro/flash-calendar": minor
+---
+
+Added support for react-native-web Pressable InteractionState to support hovered and focused alongside pressed

--- a/apps/docs/docs/fundamentals/customization.mdx
+++ b/apps/docs/docs/fundamentals/customization.mdx
@@ -219,3 +219,83 @@ export const PerfTestCalendarItemDayWithContainer = ({
   );
 };
 ```
+
+### Overriding the hovered and focused interaction states
+
+If you need to support web [Pressable InteractionStates](https://necolas.github.io/react-native-web/docs/pressable/#examples), you can also leverage `isHovered` and `isFocused` alongside `isPressed`:
+
+```tsx
+import { CalendarTheme } from "@marceloterreiro/flash-calendar";
+
+const linearAccent = "#585ABF";
+
+const linearTheme: CalendarTheme = {
+  rowMonth: {
+    content: {
+      textAlign: "left",
+      color: "rgba(255, 255, 255, 0.5)",
+      fontWeight: "700",
+    },
+  },
+  rowWeek: {
+    container: {
+      borderBottomWidth: 1,
+      borderBottomColor: "rgba(255, 255, 255, 0.1)",
+      borderStyle: "solid",
+    },
+  },
+  itemWeekName: { content: { color: "rgba(255, 255, 255, 0.5)" } },
+  itemDayContainer: {
+    activeDayFiller: {
+      backgroundColor: linearAccent,
+    },
+  },
+  itemDay: {
+    idle: ({ isPressed, isHovered, isWeekend }) => ({
+      container: {
+        backgroundColor: isPressed || isHovered ? linearAccent : "transparent",
+        borderRadius: 4,
+      },
+      content: {
+        color: isWeekend && !isPressed ? "rgba(255, 255, 255, 0.5)" : "#ffffff",
+      },
+    }),
+    today: ({ isPressed, isHovered }) => ({
+      container: {
+        borderColor: "rgba(255, 255, 255, 0.5)",
+        borderRadius: isPressed || isHovered ? 4 : 30,
+        backgroundColor: isPressed || isHovered ? linearAccent : "transparent",
+      },
+      content: {
+        color: isPressed || isHovered ? "#ffffff" : "rgba(255, 255, 255, 0.5)",
+      },
+    }),
+    active: ({ isEndOfRange, isStartOfRange }) => ({
+      container: {
+        backgroundColor: linearAccent,
+        borderTopLeftRadius: isStartOfRange ? 4 : 0,
+        borderBottomLeftRadius: isStartOfRange ? 4 : 0,
+        borderTopRightRadius: isEndOfRange ? 4 : 0,
+        borderBottomRightRadius: isEndOfRange ? 4 : 0,
+      },
+      content: {
+        color: "#ffffff",
+      },
+    }),
+  },
+};
+
+export const LinearCalendar = memo(() => {
+  return (
+    <Calendar
+      calendarDayHeight={30}
+      calendarFirstDayOfWeek="sunday"
+      calendarMonthId={toDateId(new Date())}
+      calendarRowHorizontalSpacing={16}
+      calendarRowVerticalSpacing={16}
+      onCalendarDayPress={(dateId) => console.log(`Pressed date ${dateId}`)}
+      theme={linearTheme}
+    />
+  );
+});
+```

--- a/apps/example/src/components/GithubIssues/CalendarListGithubIssues.stories.tsx
+++ b/apps/example/src/components/GithubIssues/CalendarListGithubIssues.stories.tsx
@@ -9,7 +9,6 @@ import type { Meta } from "@storybook/react";
 import { useCallback, useMemo, useState } from "react";
 import { Alert, Text, View } from "react-native";
 import { useTheme } from "@/hooks/useTheme";
-import { VStack } from "@/components/VStack";
 
 const CalendarMeta: Meta<typeof Calendar> = {
   title: "Calendar.List/Github Issues",


### PR DESCRIPTION
Adding support for web interaction states (like hovered and focused):

https://necolas.github.io/react-native-web/docs/pressable/#examples

Resolves https://github.com/MarceloPrado/flash-calendar/issues/58