### PR TITLE
fix: scroll to month cuts off month name

### DIFF
--- a/packages/flash-calendar/src/components/CalendarList.tsx
+++ b/packages/flash-calendar/src/components/CalendarList.tsx
@@ -288,8 +288,11 @@ export const CalendarList = memo(
         // Wait for the next render cycle to ensure the list has been
         // updated with the new months.
         setTimeout(() => {
-          flashListRef.current?.scrollToOffset({
-            offset: getScrollOffsetForMonth(date) + additionalOffset,
+          const monthId = toDateId(startOfMonth(date));
+          const index = monthList.findIndex((month) => month.id === monthId);
+
+          flashListRef.current?.scrollToIndex({
+            index,
             animated,
           });
         }, 0);


### PR DESCRIPTION
Uses index to scroll to month instead of calculating offset